### PR TITLE
Update crate edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["cache", "data-structure", "iterator", "peek", "nth"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/zacharygolba/peek-nth"
+edition = "2018"
 
 [dependencies]
 smallvec = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["cache", "data-structure", "iterator", "peek", "nth"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/zacharygolba/peek-nth"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 smallvec = "0.6.0"

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ jobs:
             rustup install stable nightly
             rustup default stable
             rustup component add rustfmt-preview
-            cargo +nightly install clippy --force
+            rustup component add clippy
       - save_cache:
           key: cache-{{ checksum "circle.yml" }}
           paths:
@@ -24,7 +24,7 @@ jobs:
           command: cargo fmt -- --error-on-unformatted --write-mode diff
       - run:
           name: Running Clippy
-          command: cargo +nightly clippy
+          command: cargo clippy
       - run:
           name: Running Tests
           command: cargo test

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ jobs:
             - /usr/local/cargo
       - run:
           name: Checking Style
-          command: cargo fmt -- --error-on-unformatted --write-mode diff
+          command: cargo fmt -- --check
       - run:
           name: Running Clippy
           command: cargo clippy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 //! }
 //!```
 
-extern crate smallvec;
 
 use std::iter::{DoubleEndedIterator, ExactSizeIterator};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 //! }
 //!```
 
-
 use std::iter::{DoubleEndedIterator, ExactSizeIterator};
 
 use smallvec::SmallVec;


### PR DESCRIPTION
Your (very useful) crate has no edition specified in the `Cargo.toml` file, so cargo uses the [default 2015 edition](https://doc.rust-lang.org/cargo/reference/manifest.html#the-edition-field). Since this is already a bit outdated, I therefore first upgraded the edition to 2018 and then again to edition 2021 according to the instructions at [https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html).